### PR TITLE
chore : update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "com.example.android.sunshine"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -28,21 +27,21 @@ android {
 
 // Versions number variables are defined in the module build.gradle file
 dependencies {
-    compile "com.android.support:appcompat-v7:$support_version"
-    compile "com.android.support:recyclerview-v7:$support_version"
-    compile "com.android.support:preference-v7:$support_version"
-    compile "com.android.support.constraint:constraint-layout:$constraint_layout_version"
-    compile "com.firebase:firebase-jobdispatcher:$firebase_jobdispatcher_version"
-    compile "android.arch.lifecycle:runtime:$arch_version"
-    compile "android.arch.lifecycle:extensions:$arch_version"
+    implementation "com.android.support:appcompat-v7:$support_version"
+    implementation "com.android.support:recyclerview-v7:$support_version"
+    implementation "com.android.support:preference-v7:$support_version"
+    implementation "com.android.support.constraint:constraint-layout:$constraint_layout_version"
+    implementation "com.firebase:firebase-jobdispatcher:$firebase_jobdispatcher_version"
+    implementation "android.arch.lifecycle:runtime:$arch_version"
+    implementation "android.arch.lifecycle:extensions:$arch_version"
     annotationProcessor "android.arch.lifecycle:compiler:$arch_version"
-    compile "android.arch.persistence.room:runtime:$arch_version"
+    implementation "android.arch.persistence.room:runtime:$arch_version"
     annotationProcessor "android.arch.persistence.room:compiler:$arch_version"
 
     // Instrumentation dependencies use androidTestCompile"
     // (as opposed to testCompile for local unit tests run in the JVM"
-    androidTestCompile "junit:junit:$junit_version"
-    androidTestCompile "com.android.support:support-annotations:$support_version"
-    androidTestCompile "com.android.support.test:runner:$support_test_version"
-    androidTestCompile "com.android.support.test:rules:$support_test_version"
+    androidTestImplementation "junit:junit:$junit_version"
+    androidTestImplementation "com.android.support:support-annotations:$support_version"
+    androidTestImplementation "com.android.support.test:runner:$support_test_version"
+    androidTestImplementation "com.android.support.test:rules:$support_test_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,16 +6,16 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha11'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
-ext.arch_version = "1.0.0-alpha8"
-ext.support_version = "26.0.1"
-ext.constraint_layout_version = "1.1.0-beta1"
+ext.arch_version = "1.1.1"
+ext.support_version = "27.1.1"
+ext.constraint_layout_version = "2.0.0-alpha2"
 ext.firebase_jobdispatcher_version = "0.7.0"
 ext.junit_version = "4.12"
 ext.support_test_version = "1.0.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 03 09:55:05 PDT 2017
+#Sat Sep 22 11:47:04 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
targey SDK version 27
replaced `compile` with `implementation`