### PR TITLE
Updated code and dependencies to build on Android Studio 3.2 (pre-androidx)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,18 +38,12 @@ dependencies {
 
     // ViewModel and LiveData
     implementation "android.arch.lifecycle:extensions:$arch_version"
-    //     Support library depends on this lightweight import ??
-    implementation "android.arch.lifecycle:runtime:$arch_version"
-
-//    annotationProcessor "android.arch.lifecycle:compiler:$arch_version"
     implementation "android.arch.lifecycle:common-java8:$arch_version"
-
     implementation "android.arch.persistence.room:runtime:$arch_version"
     annotationProcessor "android.arch.persistence.room:compiler:$arch_version"
 
-    // optional - Test helpers for LiveData
+    // optional - Test helpers for LiveData and Room
     testImplementation "android.arch.core:core-testing:$arch_version"
-    // Test helpers
     testImplementation "android.arch.persistence.room:testing:$arch_version"
 
     // Instrumentation dependencies use androidTestImplementation"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.example.android.sunshine"
-        minSdkVersion 14
-        targetSdkVersion 26
+        minSdkVersion 19
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -28,21 +28,35 @@ android {
 
 // Versions number variables are defined in the module build.gradle file
 dependencies {
-    compile "com.android.support:appcompat-v7:$support_version"
-    compile "com.android.support:recyclerview-v7:$support_version"
-    compile "com.android.support:preference-v7:$support_version"
-    compile "com.android.support.constraint:constraint-layout:$constraint_layout_version"
-    compile "com.firebase:firebase-jobdispatcher:$firebase_jobdispatcher_version"
-    compile "android.arch.lifecycle:runtime:$arch_version"
-    compile "android.arch.lifecycle:extensions:$arch_version"
-    annotationProcessor "android.arch.lifecycle:compiler:$arch_version"
-    compile "android.arch.persistence.room:runtime:$arch_version"
+    implementation "com.android.support:appcompat-v7:$support_version"
+    implementation "com.android.support:recyclerview-v7:$support_version"
+    implementation "com.android.support:preference-v7:$support_version"
+    implementation "com.android.support.constraint:constraint-layout:$constraint_layout_version"
+    implementation "com.firebase:firebase-jobdispatcher:$firebase_jobdispatcher_version"
+
+    // https://developer.android.com/topic/libraries/architecture/adding-components
+
+    // ViewModel and LiveData
+    implementation "android.arch.lifecycle:extensions:$arch_version"
+    //     Support library depends on this lightweight import ??
+    implementation "android.arch.lifecycle:runtime:$arch_version"
+
+//    annotationProcessor "android.arch.lifecycle:compiler:$arch_version"
+    implementation "android.arch.lifecycle:common-java8:$arch_version"
+
+    implementation "android.arch.persistence.room:runtime:$arch_version"
     annotationProcessor "android.arch.persistence.room:compiler:$arch_version"
 
-    // Instrumentation dependencies use androidTestCompile"
+    // optional - Test helpers for LiveData
+    testImplementation "android.arch.core:core-testing:$arch_version"
+    // Test helpers
+    testImplementation "android.arch.persistence.room:testing:$arch_version"
+
+    // Instrumentation dependencies use androidTestImplementation"
     // (as opposed to testCompile for local unit tests run in the JVM"
-    androidTestCompile "junit:junit:$junit_version"
-    androidTestCompile "com.android.support:support-annotations:$support_version"
-    androidTestCompile "com.android.support.test:runner:$support_test_version"
-    androidTestCompile "com.android.support.test:rules:$support_test_version"
+    androidTestImplementation "junit:junit:$junit_version"
+    androidTestImplementation "com.android.support:support-annotations:$support_version"
+    androidTestImplementation "com.android.support.test:runner:$support_test_version"
+    androidTestImplementation "com.android.support.test:rules:$support_test_version"
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,5 +52,4 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:$support_version"
     androidTestImplementation "com.android.support.test:runner:$support_test_version"
     androidTestImplementation "com.android.support.test:rules:$support_test_version"
-
 }

--- a/app/src/main/java/com/example/android/sunshine/ui/detail/DetailActivity.java
+++ b/app/src/main/java/com/example/android/sunshine/ui/detail/DetailActivity.java
@@ -15,10 +15,11 @@
  */
 package com.example.android.sunshine.ui.detail;
 
-import android.arch.lifecycle.LifecycleActivity;
+import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.ViewModelProviders;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 
 import com.example.android.sunshine.R;
 import com.example.android.sunshine.data.database.WeatherEntry;
@@ -32,7 +33,7 @@ import java.util.Date;
 /**
  * Displays single day's forecast
  */
-public class DetailActivity extends LifecycleActivity {
+public class DetailActivity extends AppCompatActivity implements LifecycleOwner {
 
     public static final String WEATHER_ID_EXTRA = "WEATHER_ID_EXTRA";
 

--- a/app/src/main/java/com/example/android/sunshine/ui/list/MainActivity.java
+++ b/app/src/main/java/com/example/android/sunshine/ui/list/MainActivity.java
@@ -15,10 +15,11 @@
  */
 package com.example.android.sunshine.ui.list;
 
-import android.arch.lifecycle.LifecycleActivity;
+import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -34,8 +35,9 @@ import java.util.Date;
 /**
  * Displays a list of the next 14 days of forecasts
  */
-public class MainActivity extends LifecycleActivity implements
-        ForecastAdapter.ForecastAdapterOnItemClickHandler {
+public class MainActivity extends AppCompatActivity implements LifecycleOwner,
+                                                    ForecastAdapter.ForecastAdapterOnItemClickHandler
+                                                     {
 
     private ForecastAdapter mForecastAdapter;
     private RecyclerView mRecyclerView;

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext.support_test_version = "1.0.0"
 allprojects {
     repositories {
         jcenter()
-        maven { url 'https://dl.google.com/dl/android/maven2/' }
+        maven { url 'https://maven.google.com' }
         google()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,24 +6,25 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
-ext.arch_version = "1.0.0-alpha8"
-ext.support_version = "26.0.1"
-ext.constraint_layout_version = "1.1.0-beta1"
-ext.firebase_jobdispatcher_version = "0.7.0"
+ext.arch_version = "1.1.1"
+ext.support_version = "28.0.0"
+ext.constraint_layout_version = "1.1.3"
+ext.firebase_jobdispatcher_version = "0.8.5"
 ext.junit_version = "4.12"
 ext.support_test_version = "1.0.0"
 
 allprojects {
     repositories {
         jcenter()
-        maven { url 'https://maven.google.com' }
+        maven { url 'https://dl.google.com/dl/android/maven2/' }
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+


### PR DESCRIPTION
In addition to updating  dependencies, the obsolete LifecycleActivity class had to be replaced with AppCompatActivity in the Activity classes. (details below)
Builds, runs in emulator, tests pass.

"Note: Since the Architecture Components are in alpha stage, Fragment and AppCompatActivity classes cannot implement it (because we cannot add a dependency from a stable component to an unstable API). Until Lifecycle is stable, LifecycleActivity andLifecycleFragment classes are provided for convenience. After the Lifecycles project is released, support library fragments and activities will implement the LifecycleOwner interface; LifecycleActivity and LifecycleFragment will be deprecated at that time. Also, see Implementing LifecycleOwner in custom activities and fragments."

https://medium.com/@mladenrakonjac/note-since-the-architecture-components-are-in-alpha-stage-fragment-and-appcompatactivity-classes-b4b055ecd35b